### PR TITLE
fix: Wallpaper Path on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wal-theme",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
This is more of a work around:

- Paths generated by pywal on Windows aren't properly escaped
  - This causes JSON.parse to fail since there are unsupported escape sequences.

This change removes the `"wallpaper"` entry from colors.json if there is a failure.

If there is another failure, it checks to see if *any* colors are available from the colors cache file, if so it proceeds even though we couldn't get better values from colors.json (with a warning), if not we hard fail.