### PR TITLE
Fixed issue where node watched for changes in whole folder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ function autoUpdate(): fs.FSWatcher {
 	let fsWait = false;
 
 	// Watch for changes in the color palette of wal
-	return fs.watch(walCachePath, (event, filename) => {
+	return fs.watch(walColorsJsonPath, (event, filename) => {
 		if (filename) {
 			// Delay after a change is found
 			if (fsWait) {


### PR DESCRIPTION
This fixes #16 . The issue was that node was watching the whole folder and it seems like there was another file that changes before the json file and thus the extension tried to "update" the theme before the json file was updated.

Thus, the fix here was just to make it watch the json file rather than the whole cache folder (and this seems to work on my system).