### PR TITLE
Increase light mode support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,15 +104,13 @@ function generateColorThemes() {
 
 		vscode.window.showWarningMessage('Couldn\'t load all colors from pywal cache');
 	}
-	
-	const colorType = getColorType(colors[0]);
-
+		
 	// Generate the normal theme
-	const colorTheme = template(colorType, colors, false);
+	const colorTheme = template(colors, false);
 	fs.writeFileSync(path.join(__dirname,'..', 'themes', 'wal.json'), JSON.stringify(colorTheme, null, 4));
 	
 	// Generate the bordered theme
-	const colorThemeBordered = template(colorType, colors, true);
+	const colorThemeBordered = template(colors, true);
 	fs.writeFileSync(path.join(__dirname,'..', 'themes', 'wal-bordered.json'), JSON.stringify(colorThemeBordered, null, 4));
 }
 
@@ -125,12 +123,4 @@ function autoUpdate(): chokidar.FSWatcher {
 	return chokidar
 		.watch(walCachePath)
 		.on('change', generateColorThemes);
-}
-
-/**
- * Determine if the color is light or dark using HSP http://alienryderflex.com/hsp.html
- */
-function getColorType(color: Color): 'light' | 'dark' {
-	const hsp = Math.sqrt(0.299 * Math.pow(color.red(), 2) + 0.587 * Math.pow(color.green(), 2) + 0.114 * Math.pow(color.blue(), 2));
-	return (hsp > 127.5) ? 'light' : 'dark';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,13 +104,15 @@ function generateColorThemes() {
 
 		vscode.window.showWarningMessage('Couldn\'t load all colors from pywal cache');
 	}
-		
+	
+	const colorType = getColorType(colors[0]);
+
 	// Generate the normal theme
-	const colorTheme = template(colors, false);
+	const colorTheme = template(colorType, colors, false);
 	fs.writeFileSync(path.join(__dirname,'..', 'themes', 'wal.json'), JSON.stringify(colorTheme, null, 4));
 	
 	// Generate the bordered theme
-	const colorThemeBordered = template(colors, true);
+	const colorThemeBordered = template(colorType, colors, true);
 	fs.writeFileSync(path.join(__dirname,'..', 'themes', 'wal-bordered.json'), JSON.stringify(colorThemeBordered, null, 4));
 }
 
@@ -123,4 +125,12 @@ function autoUpdate(): chokidar.FSWatcher {
 	return chokidar
 		.watch(walCachePath)
 		.on('change', generateColorThemes);
+}
+
+/**
+ * Determine if the color is light or dark using HSP http://alienryderflex.com/hsp.html
+ */
+function getColorType(color: Color): 'light' | 'dark' {
+	const hsp = Math.sqrt(0.299 * Math.pow(color.red(), 2) + 0.587 * Math.pow(color.green(), 2) + 0.114 * Math.pow(color.blue(), 2));
+	return (hsp > 127.5) ? 'light' : 'dark';
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,7 +1,7 @@
 import * as Color from 'color';
 
-export default (colorType: 'dark' | 'light', colors: Color[], bordered: boolean) => ({
-  'type': colorType,
+export default (colors: Color[], bordered: boolean) => ({
+  'type': 'dark',
   'colors': {
     // Colour reference https://code.visualstudio.com/docs/getstarted/theme-color-reference
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,7 +1,7 @@
 import * as Color from 'color';
 
-export default (colors: Color[], bordered: boolean) => ({
-  'type': 'dark',
+export default (colorType: 'dark' | 'light', colors: Color[], bordered: boolean) => ({
+  'type': colorType,
   'colors': {
     // Colour reference https://code.visualstudio.com/docs/getstarted/theme-color-reference
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -258,6 +258,7 @@ export default (colorType: 'dark' | 'light', colors: Color[], bordered: boolean)
     'pickerGroup.foreground': colors[7].hex()+'b3',
     
     // DEBUG
+    'debugTokenExpression.value': colors[7].hex()+'b3',
     'debugToolBar.background': colors[0].hex(),
     // 'debugToolBar.border': '',
     


### PR DESCRIPTION
Set the debug token expression value improves using light mode wal themes:
![image](https://user-images.githubusercontent.com/661373/130897589-6a8bcd88-2512-41de-846e-c408ada14a0a.png)

Does not appear to regress dark mode significantly:
![image](https://user-images.githubusercontent.com/661373/130897717-b8370dde-860d-4413-857d-b5fb8bfc30ab.png)

Note: `'light'` mode type does not appear to have visual effect.