### PR TITLE
feat: Add colors for bracket matching

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -141,6 +141,14 @@ export default (colors: Color[], bordered: boolean) => ({
     
     'editorBracketMatch.background': colors[8].hex()+'33',
     'editorBracketMatch.border': colors[8].hex()+'55',
+
+    // BRACKET MATCHES
+    'editorBracketHighlight.foreground1': colors[6].lighten(0.25).hex(),
+    'editorBracketHighlight.foreground2': colors[5].lighten(0.25).hex(),
+    'editorBracketHighlight.foreground3': colors[4].lighten(0.25).hex(),
+    'editorBracketHighlight.foreground4': colors[3].lighten(0.4).hex(),
+    'editorBracketHighlight.foreground5': colors[2].lighten(0.25).hex(),
+    'editorBracketHighlight.foreground6': colors[1].lighten(0.25).hex(),
     
     // OVERVIEW RULER
     'editorOverviewRuler.border': colors[8].hex()+'33',

--- a/src/template.ts
+++ b/src/template.ts
@@ -143,12 +143,12 @@ export default (colors: Color[], bordered: boolean) => ({
     'editorBracketMatch.border': colors[8].hex()+'55',
 
     // BRACKET MATCHES
-    'editorBracketHighlight.foreground1': colors[6].lighten(0.25).hex(),
-    'editorBracketHighlight.foreground2': colors[5].lighten(0.25).hex(),
-    'editorBracketHighlight.foreground3': colors[4].lighten(0.25).hex(),
-    'editorBracketHighlight.foreground4': colors[3].lighten(0.4).hex(),
-    'editorBracketHighlight.foreground5': colors[2].lighten(0.25).hex(),
-    'editorBracketHighlight.foreground6': colors[1].lighten(0.25).hex(),
+    'editorBracketHighlight.foreground1': colors[6].hex(),
+    'editorBracketHighlight.foreground2': colors[5].hex(),
+    'editorBracketHighlight.foreground3': colors[4].hex(),
+    'editorBracketHighlight.foreground4': colors[3].hex(),
+    'editorBracketHighlight.foreground5': colors[2].hex(),
+    'editorBracketHighlight.foreground6': colors[1].hex(),
     
     // OVERVIEW RULER
     'editorOverviewRuler.border': colors[8].hex()+'33',


### PR DESCRIPTION
- Adding colors for August 2021 [fast bracket pair colorization](https://code.visualstudio.com/updates/v1_60#_high-performance-bracket-pair-colorization)

Default Colors:
![image](https://user-images.githubusercontent.com/661373/132998648-dc1f5f6f-e47a-4ce9-b8d4-54ec58e98877.png)

[Samurai Doge](https://galopes.artstation.com/projects/rAGoB5) - [haishoku](https://github.com/LanceGin/haishoku) colors:
![image](https://user-images.githubusercontent.com/661373/132998675-2cf834ff-bbb2-4da7-979f-2ce174a63287.png)